### PR TITLE
Add --check mode for CI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,8 +42,7 @@ program
     }
     const lus = new Lus(lusOptions);
 
-    lus.run().catch((error: unknown) => {
-      console.error(error);
+    lus.run().catch((error: Error) => {
       process.exit(1);
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ program
   .argument('<files/globs...>', 'Files or globs to format on')
   .option('-v, --verbose', 'verbose output', false)
   .option('-c, --config <config>', 'the config file to use', '.stylusrc')
+  .option('-C, --check', 'check if files are formatted', false)
   .option(
     '-i, --ignore <globs>',
     'ignore files using these comma-separated glob patterns',
@@ -40,7 +41,12 @@ program
       globs,
     }
     const lus = new Lus(lusOptions);
-    lus.run();
+    
+    lus.run().catch((error: unknown) => {
+      console.error(error);
+      process.exit(1);
+    });
+    
   })
 
 program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,12 +41,12 @@ program
       globs,
     }
     const lus = new Lus(lusOptions);
-    
+
     lus.run().catch((error: unknown) => {
       console.error(error);
       process.exit(1);
     });
-    
+
   })
 
 program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ program
   .argument('<files/globs...>', 'Files or globs to format on')
   .option('-v, --verbose', 'verbose output', false)
   .option('-c, --config <config>', 'the config file to use', '.stylusrc')
-  .option('-C, --check', 'check if files are formatted', false)
+  .option('-C, --check', 'only check if files are formatted', false)
   .option(
     '-i, --ignore <globs>',
     'ignore files using these comma-separated glob patterns',

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -138,6 +138,14 @@ describe('Lus formatter', () => {
       testVueContent(outputStyleWithConfig)
     );
   });
+
+  it('throws when file is not formatted if option `check` is true', async () => {
+    fs.writeFileSync('.test/Test.vue', testVueContent(inputStyle), 'utf-8');
+    const defaultTestLus = new Lus({ ...testLusOptions, check: true });
+    await expect(defaultTestLus.format('.test/Test.vue')).rejects.toThrow(
+      'File .test/Test.vue is not formatted'
+    );
+  });
 });
 
 describe('Lus runner', () => {

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -65,7 +65,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  fs.rmdirSync('.test', { recursive: true });
+  fs.rmSync('.test', { recursive: true });
 });
 
 describe('Lus logger', () => {

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -5,7 +5,6 @@ import type { LusOptions } from './lib';
 const testLusOptions: LusOptions = {
   verbose: true,
   config: '.test/.stylusrc',
-  ignore: [],
   globs: ['**/*.vue'],
 };
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -41,7 +41,7 @@ export interface LusOptions {
    */
   config: string;
   /**
-   * Check mode only
+   * Only check if files are formatted
    */
   check: boolean;
   /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -133,12 +133,12 @@ export class Lus {
           }
         }
 
-        if (!this.options.check) {
-          // Write new file content
-          fs.writeFileSync(filePath, newFileContent, 'utf-8');
-        } else if (fileContent !== newFileContent) {
-          throw `File ${filePath} is not formatted`;
+        if (this.options.check && fileContent !== newFileContent) {
+          throw new Error(`File ${filePath} is not formatted`);
         }
+
+        // Write new file content
+        fs.writeFileSync(filePath, newFileContent, 'utf-8');
 
         resolve();
       } catch (error: any) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -133,10 +133,10 @@ export class Lus {
           }
         }
 
-        if(!this.options.check) {
+        if (!this.options.check) {
           // Write new file content
           fs.writeFileSync(filePath, newFileContent, 'utf-8');
-        }else if(fileContent !== newFileContent) {
+        } else if (fileContent !== newFileContent) {
           throw `File ${filePath} is not formatted`;
         }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -142,7 +142,7 @@ export class Lus {
 
         resolve();
       } catch (error: any) {
-        this.logger.error(error);
+        this.logger.error(error.message);
         reject(error);
       }
     });
@@ -173,7 +173,6 @@ export class Lus {
           });
         }, Promise.resolve());
       } catch (error: unknown) {
-        this.logger.error(error);
         reject(error);
       }
     });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -35,7 +35,7 @@ export interface LusOptions {
   /**
    * Verbose output
    */
-  verbose: boolean;
+  verbose?: boolean;
   /**
    * The config file name
    */
@@ -43,11 +43,11 @@ export interface LusOptions {
   /**
    * Only check if files are formatted
    */
-  check: boolean;
+  check?: boolean;
   /**
    * Ignore files matching these glob patterns
    */
-  ignore: string[];
+  ignore?: string[];
   /**
    * The glob patterns to match files
    */
@@ -66,7 +66,7 @@ export class Lus {
     // Assign options
     this.options = options;
     // Create logger
-    this.logger = new Logger(options.verbose);
+    this.logger = new Logger(options.verbose ?? false);
     // Get stylusrc options
     this.stylusSupremacyOptions = this.getConfigFileOptions();
   }
@@ -155,7 +155,7 @@ export class Lus {
   public async run(): Promise<void> {
     // Build glob options
     const globOptions = {
-      ignore: ['node_modules/**/*', ...this.options.ignore],
+      ignore: ['node_modules/**/*', ...(this.options.ignore ?? [])],
     };
     return new Promise((resolve, reject) => {
       try {


### PR DESCRIPTION
Here is a proposal in order to run the script as a simple file format checker, which would exit on the first file with incorrect formatting (useful for CI).
I actually have no idea how to do that properly, but this seems to work on my end.
I've rebased this PR on this other PR https://github.com/qnp/lus/pull/1 for practical reasons, I will adjust depending of the outcome of that other PR.

cheers